### PR TITLE
DTSPO-14034 - Add jenkins arm image

### DIFF
--- a/components/shared-image-gallery/variables.tf
+++ b/components/shared-image-gallery/variables.tf
@@ -42,6 +42,10 @@ variable "images" {
       "sku"           = "20.04-LTS"
       "vm_generation" = "V1"
     },
+    "jenkins-ubuntu-arm" = {
+      "sku"           = "20.04-LTS"
+      "vm_generation" = "V2"
+    },
     "devops-ubuntu" = {
       "sku"           = "22.04-LTS"
       "vm_generation" = "V2"


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-14034

### Change description ###
Add base image for jenkins ubuntu on arm
Current jenkins ubuntu shared image is v1 but arm requires v2

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
